### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/weekly-cleanup.yml
+++ b/.github/workflows/weekly-cleanup.yml
@@ -8,6 +8,10 @@ on:
 jobs:
   stale:
     name: Destalinate!
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Close stale issues and pull requests

--- a/.github/workflows/weekly-cleanup.yml
+++ b/.github/workflows/weekly-cleanup.yml
@@ -12,7 +12,7 @@ jobs:
       actions: write
       #contents: write # only for delete-branch option
       issues: write
-      pull-requests: write      
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Close stale issues and pull requests

--- a/.github/workflows/weekly-cleanup.yml
+++ b/.github/workflows/weekly-cleanup.yml
@@ -9,9 +9,10 @@ jobs:
   stale:
     name: Destalinate!
     permissions:
-      contents: write
+      actions: write
+      #contents: write # only for delete-branch option
       issues: write
-      pull-requests: write
+      pull-requests: write      
     runs-on: ubuntu-latest
     steps:
       - name: Close stale issues and pull requests


### PR DESCRIPTION
Potential fix for [https://github.com/advanced-security/ghas-to-csv/security/code-scanning/1](https://github.com/advanced-security/ghas-to-csv/security/code-scanning/1)

To resolve the issue, add an explicit `permissions` block to the relevant job (or at the root of the workflow for global effect) to restrict the permissions granted to the workflow's `GITHUB_TOKEN`. The minimal correct permissions needed for `actions/stale` to label, comment, and close issues/PRs are `contents: write`, `issues: write`, and `pull-requests: write`. Insert this block under `jobs.stale:` in `.github/workflows/weekly-cleanup.yml` (ideally directly below `name:` for visibility). No new imports or methods are required—only this YAML configuration update.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
